### PR TITLE
Removes the envId from the Postman environment collection

### DIFF
--- a/postman/JitterbitConnectorManagerAPI.collection.json
+++ b/postman/JitterbitConnectorManagerAPI.collection.json
@@ -1,7 +1,7 @@
 {
 	"info": {
 		"_postman_id": "16d87af7-78df-4318-a042-32cdebc16459",
-		"name": "JitterbitConnectorManagerAPI",
+		"name": "Jitterbit Connector Manager API",
 		"description": "The Jitterbit Connector Manager API allows a developer to log in to Jitterbit Harmony and manage their custom connectors. Custom connectors are listed, registered, and deleted through this API. A custom connector must be registered before it can be built, deployed to a Private Agent, and used through Jitterbit Harmony.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},

--- a/postman/JitterbitConnectorManagerAPIEnvVariables.json
+++ b/postman/JitterbitConnectorManagerAPIEnvVariables.json
@@ -1,6 +1,6 @@
 {
   "id": "5e142948-5d1d-4fb7-bdbe-c71b44a87c53",
-  "name": "jb-connector-manager-api",
+  "name": "Jitterbit Connector Manager API",
   "values": [
     {
       "key": "host",
@@ -22,12 +22,6 @@
     },
     {
       "key": "orgId",
-      "value": "",
-      "type": "text",
-      "enabled": true
-    },
-    {
-      "key": "envId",
       "value": "",
       "type": "text",
       "enabled": true


### PR DESCRIPTION
Removes the `envId` from the Postman environment collection as it is no longer used. (Assuming it ever was.)

- Adds spaces to the names of the collections so that they are easier to read once imported.
- Renames the environment variables files so that it matches the name of the other file.

A matching PR will be needed in the Dev Portal docs to match this.