### PR TITLE
Adjust execute statements to follow a consistent design pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,15 @@ include attributes specific to the connector(s) within the `MANIFEST.MF` file. T
 registration process need to be included in the manifest, as described above. For additional details, check the
 [PACKAGING.md](PACKAGING.md).
 
-Skipping the details, and to directly build the Dropbox connector, run this command:
+Additionally, tests are run as part of the build. For the tests to run, you will need the Dropbox `app-key` and
+`access-token` keys that you obtained earlier. They must be defined in the build environment as the test uses those
+keys.
 
+Skipping the details, and to directly build the Dropbox connector, run these commands (after substituting in your
+values for the `APP_KEY` and `ACCESS_TOKEN` environment variables in this example):
+
+    $ export APP_KEY=<app-key>
+    $ export ACCESS_TOKEN=<access-token>
     $ mvn jaxb2:xjc compile install
 
 

--- a/src/main/java/org/jitterbit/connector/dropbox/activities/FetchFileActivity.java
+++ b/src/main/java/org/jitterbit/connector/dropbox/activities/FetchFileActivity.java
@@ -81,6 +81,7 @@ public class FetchFileActivity extends BaseDropboxActivity {
   @Override
   public void execute(JitterbitActivity.ExecutionContext context) throws ActivityExecutionException {
     logger.info("Executing Activity: " + getName());
+    DropboxConnection connection = null;
     String path = "";
     try {
       String folder = context.getFunctionParameters().get("folder");
@@ -94,7 +95,7 @@ public class FetchFileActivity extends BaseDropboxActivity {
         path = folder + "/" + fileName;
       }
       logger.info("Fetching: " + path);
-      DropboxConnection connection = (DropboxConnection) context.getConnection();
+      connection = (DropboxConnection) context.getConnection();
       DbxClientV2 client = connection.getClient();
 
       DbxDownloader<FileMetadata> result = client.files().download(path);
@@ -130,8 +131,14 @@ public class FetchFileActivity extends BaseDropboxActivity {
       try {
         context.getResponsePayload().getOutputStream().flush();
         context.getResponsePayload().getOutputStream().close();
+        if (connection != null) {
+          connection.close();
+        }
       } catch (Exception x) {
-        logger.warning(x.getMessage());
+        String message = "Getting exception while closing: " + x.getLocalizedMessage();
+        logger.severe(message);
+        x.printStackTrace();
+        throw new RuntimeException(message, x);
       }
     }
   }

--- a/src/main/java/org/jitterbit/connector/dropbox/activities/FetchFileActivity.java
+++ b/src/main/java/org/jitterbit/connector/dropbox/activities/FetchFileActivity.java
@@ -77,6 +77,7 @@ public class FetchFileActivity extends BaseDropboxActivity {
    *
    * @param context the context for the activity
    * @throws ActivityExecutionException if there is an error while executing the activity
+   * @throws RuntimeException if there is an error while closing the activity
    */
   @Override
   public void execute(JitterbitActivity.ExecutionContext context) throws ActivityExecutionException {

--- a/src/main/java/org/jitterbit/connector/dropbox/activities/GetFileActivity.java
+++ b/src/main/java/org/jitterbit/connector/dropbox/activities/GetFileActivity.java
@@ -80,10 +80,11 @@ public class GetFileActivity extends BaseDropboxActivity {
   @Override
   public void execute(ExecutionContext context) throws ActivityExecutionException {
     logger.info("Executing Activity: " + getName());
-    DropboxConnection connection = (DropboxConnection) context.getConnection();
+    DropboxConnection connection = null;
     String folder = context.getFunctionParameters().get("folder");
     String obj = context.getFunctionParameters().get("list-object");
     try {
+      connection = (DropboxConnection) context.getConnection();
       JsonElement json = new JsonParser().parse(obj);
       String filename = json.getAsJsonObject().getAsJsonPrimitive("name").getAsString();
       DbxClientV2 client = connection.getClient();
@@ -95,8 +96,17 @@ public class GetFileActivity extends BaseDropboxActivity {
       throw new ActivityExecutionException(Messages.DROPBOX_CODE06,
         Messages.getMessage(Messages.DROPBOX_CODE06_MSG, new Object[]{getName(), t.getLocalizedMessage()}), t);
     } finally {
-      if (connection != null) {
-        connection.close();
+      try {
+        context.getResponsePayload().getOutputStream().flush();
+        context.getResponsePayload().getOutputStream().close();
+        if (connection != null) {
+          connection.close();
+        }
+      } catch (Exception x) {
+        String message = "Getting exception while closing: " + x.getLocalizedMessage();
+        logger.severe(message);
+        x.printStackTrace();
+        throw new RuntimeException(message, x);
       }
     }
   }

--- a/src/main/java/org/jitterbit/connector/dropbox/activities/GetFileActivity.java
+++ b/src/main/java/org/jitterbit/connector/dropbox/activities/GetFileActivity.java
@@ -76,6 +76,7 @@ public class GetFileActivity extends BaseDropboxActivity {
    * as part of the `context`.
    * @param context the context for the activity
    * @throws ActivityExecutionException if there is an error while executing the activity
+   * @throws RuntimeException if there is an error while closing the activity
    */
   @Override
   public void execute(ExecutionContext context) throws ActivityExecutionException {

--- a/src/main/java/org/jitterbit/connector/dropbox/activities/ProcessFileActivity.java
+++ b/src/main/java/org/jitterbit/connector/dropbox/activities/ProcessFileActivity.java
@@ -82,6 +82,7 @@ public class ProcessFileActivity extends BaseDropboxActivity {
   @Override
   public void execute(JitterbitActivity.ExecutionContext context) throws ActivityExecutionException {
     logger.info("Executing Activity: " + getName());
+    DropboxConnection connection = null;
     String folder = "";
     String path = "";
     DbxDownloader<FileMetadata> result;
@@ -97,7 +98,7 @@ public class ProcessFileActivity extends BaseDropboxActivity {
         path = folder + "/" + fileName;
       }
 
-      DropboxConnection connection = (DropboxConnection) context.getConnection();
+      connection = (DropboxConnection) context.getConnection();
       DbxClientV2 client = connection.getClient();
       result = client.files().download(path);
       result.download(context.getResponsePayload().getOutputStream());
@@ -110,8 +111,14 @@ public class ProcessFileActivity extends BaseDropboxActivity {
       try {
         context.getResponsePayload().getOutputStream().flush();
         context.getResponsePayload().getOutputStream().close();
+        if (connection != null) {
+          connection.close();
+        }
       } catch (Exception x) {
-        logger.warning(x.getMessage());
+        String message = "Getting exception while closing: " + x.getLocalizedMessage();
+        logger.severe(message);
+        x.printStackTrace();
+        throw new RuntimeException(message, x);
       }
     }
   }

--- a/src/main/java/org/jitterbit/connector/dropbox/activities/ProcessFileActivity.java
+++ b/src/main/java/org/jitterbit/connector/dropbox/activities/ProcessFileActivity.java
@@ -78,6 +78,7 @@ public class ProcessFileActivity extends BaseDropboxActivity {
    *
    * @param context the context for the activity
    * @throws ActivityExecutionException if there is an error while executing the activity
+   * @throws RuntimeException if there is an error while closing the activity
    */
   @Override
   public void execute(JitterbitActivity.ExecutionContext context) throws ActivityExecutionException {

--- a/src/main/java/org/jitterbit/connector/dropbox/activities/PutFileActivity.java
+++ b/src/main/java/org/jitterbit/connector/dropbox/activities/PutFileActivity.java
@@ -82,6 +82,7 @@ public class PutFileActivity extends BaseDropboxActivity {
    *
    * @param context the context for the activity
    * @throws ActivityExecutionException if there is an error while executing the activity
+   * @throws RuntimeException if there is an error while closing the activity
    */
   @Override
   public void execute(ExecutionContext context) throws ActivityExecutionException {


### PR DESCRIPTION
Update README with instructions on using the APP_KEY and ACCESS_TOKEN environment variables and adjusting the execute statements to follow a consistent design pattern.